### PR TITLE
Bugfix:  fix bug causing infinite recursion with circular references

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,41 @@ console.log(jsonthis.toJson(user, {maskChar: "-"}));
 // { id: 1, email: 'j------e@gmail.com' }
 ```
 
+## Circular References
+
+Jsonthis can detect circular references out of the box. When serializing an object with circular references, the default
+behavior is to throw a `CircularReferenceError`. However, you can customize this behavior by providing a custom handler:
+
+```typescript
+function serializeCircularReference(value: any): any {
+    return { $ref: `$${value.constructor.name}(${value.id})` };
+}
+
+@Json
+class User {
+    id: number;
+    name: string;
+    friend?: User;
+
+    constructor(id: number, name: string) {
+        this.id = id;
+        this.name = name;
+    }
+}
+
+const user = new User(1, "John");
+user.friend = new User(2, "Jane");
+user.friend.friend = user;
+
+const jsonthis = new Jsonthis({circularReferenceSerializer: serializeCircularReference});
+console.log(jsonthis.toJson(user));
+// {
+//   id: 1,
+//   name: 'John',
+//   friend: { id: 2, name: 'Jane', friend: { '$ref': '$User(1)' } }
+// }
+```
+
 ## Sequelize support
 Jsonthis seamlessly integrates with the [Sequelize](https://sequelize.org/) ORM library.
 To utilize Jsonthis with Sequelize, simply specify it in the library constructor:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export {
-    Jsonthis, JsonthisOptions, Json, JsonField, JsonFieldOptions, JsonFieldFunction, CircularReferenceError
+    Jsonthis,
+    JsonthisOptions,
+    Json,
+    JsonField,
+    JsonFieldOptions,
+    JsonFieldFunction,
+    CircularReferenceError
 } from './jsonthis';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export {Jsonthis, JsonthisOptions, Json, JsonField, JsonFieldOptions, JsonFieldFunction} from './jsonthis';
+export {
+    Jsonthis, JsonthisOptions, Json, JsonField, JsonFieldOptions, JsonFieldFunction, CircularReferenceError
+} from './jsonthis';

--- a/src/jsonthis.test.ts
+++ b/src/jsonthis.test.ts
@@ -271,3 +271,34 @@ test("serialize with different casing options", () => {
         RegisteredAt: user.registeredAt
     });
 });
+
+test("should serialize circular references", () => {
+    @Json
+    class User {
+        id: number;
+        name: string;
+        friend?: User;
+
+        constructor(id: number, name: string) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    const user = new User(1, "John");
+    user.friend = new User(2, "Jane");
+    user.friend.friend = user;
+
+    const jsonthis = new Jsonthis();
+    expect(jsonthis.toJson(user)).toStrictEqual({
+        id: 1,
+        name: "John",
+        friend: {
+            id: 2,
+            name: "Jane",
+            friend: {
+                $ref: "$1"
+            }
+        }
+    });
+});

--- a/src/jsonthis.test.ts
+++ b/src/jsonthis.test.ts
@@ -290,7 +290,7 @@ test("should serialize circular references", () => {
     user.friend.friend = user;
 
     // Default is to throw an error.
-    expect(() => new Jsonthis().toJson(user)).toThrow(new CircularReferenceError());
+    expect(() => new Jsonthis().toJson(user)).toThrow(new CircularReferenceError(user, user.friend));
 
     function serializeCircularReference(value: any): any {
         return { $ref: `$${value.constructor.name}(${value.id})` };

--- a/src/jsonthis.ts
+++ b/src/jsonthis.ts
@@ -75,8 +75,13 @@ export type JsonthisOptions = {
 }
 
 export class CircularReferenceError extends Error {
-    constructor() {
+    public parent: any;
+    public ref: any;
+
+    constructor(ref: any, parent: any) {
         super("Circular reference detected");
+        this.parent = parent;
+        this.ref = ref;
     }
 }
 
@@ -122,7 +127,7 @@ export class Jsonthis {
     private serializeCircularReference(value: any, context?: any, parent?: any): any {
         if (this.options.circularReferenceSerializer)
             return this.options.circularReferenceSerializer(value, context, parent);
-        throw new CircularReferenceError();
+        throw new CircularReferenceError(value, parent);
     }
 
     /**


### PR DESCRIPTION
This PR also add `circularReferenceSerializer` option to `JsonthisOptions` to customize how to handle circular references. (Default behaviour is to throw new `CircularReferenceError`)